### PR TITLE
Added better support for modded planks

### DIFF
--- a/src/main/java/org/blockartistry/mod/DynSurround/client/footsteps/game/system/ForgeDictionary.java
+++ b/src/main/java/org/blockartistry/mod/DynSurround/client/footsteps/game/system/ForgeDictionary.java
@@ -63,7 +63,7 @@ public final class ForgeDictionary {
 			"blockHeeEndium" };
 
 	private static final String[] woodBlocks = { "logWood", "planksWood", "slabWood", "stairWood", "plankBamboo",
-			"slabBamboo", "stairBamboo", "craftingTableWood" };
+			"slabBamboo", "stairBamboo", "craftingTableWood", "plankWood" };
 
 	private static final String[] saplings = { "treeSaplings", "saplingTree" };
 


### PR DESCRIPTION
Most definitions use plankWood, not planksWood, but, I will leave the old definition in place as well.
