### PR TITLE
Generic definitions for players to hook onto via minetweaker

### DIFF
--- a/src/main/java/org/blockartistry/mod/DynSurround/client/footsteps/game/system/ForgeDictionary.java
+++ b/src/main/java/org/blockartistry/mod/DynSurround/client/footsteps/game/system/ForgeDictionary.java
@@ -74,11 +74,11 @@ public final class ForgeDictionary {
 	private static final String[] woodBlocks = { "logWood", "planksWood", "slabWood", "stairWood", "plankBamboo",
 			"slabBamboo", "stairBamboo", "craftingTableWood", "plankWood", "genericWood" };
 
-	private static final String[] saplings = { "treeSaplings", "saplingTree", "genericSapling" };
+	private static final String[] saplings = { "treeSaplings", "saplingTree", "genericSapling", "sapling", "treeSapling" };
 
 	private static final String[] glassBlocks = { "blockGlass", "genericGlass" };
 
-	private static final String[] leafBlocks = { "treeLeaves", "leavesTree", "treeBambooLeaves", "genericLeaves" };
+	private static final String[] leafBlocks = { "treeLeaves", "leavesTree", "treeBambooLeaves", "genericLeaves", "leaves" };
 
 	private static final String[] stoneBlocks = { "stone", "cobblestone", "blockFuelCoke", "concrete", "blockCoal",
 			"andesite", "blockAndesite", "stoneAndesite", "stoneDiorite", "diorite", "blockDiorite", "blockGranite",

--- a/src/main/java/org/blockartistry/mod/DynSurround/client/footsteps/game/system/ForgeDictionary.java
+++ b/src/main/java/org/blockartistry/mod/DynSurround/client/footsteps/game/system/ForgeDictionary.java
@@ -53,7 +53,7 @@ public final class ForgeDictionary {
 			"oreCinnabar", "oreYellorite", "oreTemporal", "oreAmethyst", "oreAmber", "oreMalachite", "oreTanzanite",
 			"oreTritanium", "oreTungsten", "oreTelsalite", "oreCheese", "denseorePeridot", "denseoreZinc",
 			"denseoreRuby", "denseoreSapphire", "denseoreAmethyst", "denseoreTungsten", "oreHeeEndium", "oreStarSteel",
-			"oreColdIron", "oreAdamantine", "oreMercury", "oreFossil", "oreShadow" };
+			"oreColdIron", "oreAdamantine", "oreMercury", "oreFossil", "oreShadow", "oreGeneric" };
 
 	private static final String[] metalBlocks = { "blockIron", "blockGold", "blockCopper", "blockTin", "blockSilver",
 			"blockLead", "blockNickle", "blockPlatinum", "blockMithril", "blockElectrum", "blockInvar", "blockBronze",
@@ -69,43 +69,43 @@ public final class ForgeDictionary {
 			"trapdoorColdiron", "trapdoorElectrum", "trapdoorLead", "trapdoorNickel", "trapdoorStarsteel",
 			"trapdoorTin", "trapdoorSteel", "doorAdamantine", "doorAquarium", "doorBrass", "doorBronze", "doorColdiron",
 			"doorCopper", "doorElectrum", "doorInvar", "doorLead", "doorMithril", "doorNickel", "doorSilver",
-			"doorStarsteel", "doorSteel", "doorTin", "blockWroughtIron", "blockVoid" };
+			"doorStarsteel", "doorSteel", "doorTin", "blockWroughtIron", "blockVoid", "blockMetal" };
 
 	private static final String[] woodBlocks = { "logWood", "planksWood", "slabWood", "stairWood", "plankBamboo",
-			"slabBamboo", "stairBamboo", "craftingTableWood", "plankWood" };
+			"slabBamboo", "stairBamboo", "craftingTableWood", "plankWood", "genericWood" };
 
-	private static final String[] saplings = { "treeSaplings", "saplingTree" };
+	private static final String[] saplings = { "treeSaplings", "saplingTree", "genericSapling" };
 
-	private static final String[] glassBlocks = { "blockGlass" };
+	private static final String[] glassBlocks = { "blockGlass", "genericGlass" };
 
-	private static final String[] leafBlocks = { "treeLeaves", "leavesTree", "treeBambooLeaves" };
+	private static final String[] leafBlocks = { "treeLeaves", "leavesTree", "treeBambooLeaves", "genericLeaves" };
 
 	private static final String[] stoneBlocks = { "stone", "cobblestone", "blockFuelCoke", "concrete", "blockCoal",
 			"andesite", "blockAndesite", "stoneAndesite", "stoneDiorite", "diorite", "blockDiorite", "blockGranite",
-			"stoneGranite", "blockCharcoal" };
+			"stoneGranite", "blockCharcoal", "genericStone" };
 
 	private static final String[] sandstoneBlocks = { "sandstone", "blockPrismarine", "limestone", "stoneLimestone",
-			"blockLimestone" };
+			"blockLimestone", "genericSandstone" };
 
-	private static final String[] sandBlocks = { "sand", "blockSalt", "blockPsiDust", "denseSand", "dustAsh" };
+	private static final String[] sandBlocks = { "sand", "blockSalt", "blockPsiDust", "denseSand", "dustAsh", "genericSand" };
 
-	private static final String[] woodChests = { "chestWood", "chestTrapped" };
+	private static final String[] woodChests = { "chestWood", "chestTrapped", "genericChest" };
 
-	private static final String[] rugBlocks = { "wool", "blockClothRock", "materialBedding" };
+	private static final String[] rugBlocks = { "wool", "blockClothRock", "materialBedding", "genericWool" };
 
-	private static final String[] fenceBlocks = { "fenceWood", "fenceGateWood" };
+	private static final String[] fenceBlocks = { "fenceWood", "fenceGateWood", "genericFence" };
 
-	private static final String[] mudBlocks = { "blockSlime", "blockCheese" };
+	private static final String[] mudBlocks = { "blockSlime", "blockCheese", "genericMud", "mud" };
 
 	private static final String[] obsidianBlocks = { "oreSunstone", "blockGraphite", "basalt", "stoneBasalt",
-			"blockBasalt", "blockBloodstone" };
+			"blockBasalt", "blockBloodstone", "genericObsidian" };
 
 	private static final String[] compositeBlocks = { "blockDiamond", "blockEmerald", "blockPeridot", "blockRuby",
 			"blockSapphire", "blockVinteum", "blockChimerite", "blockBlueTopaz", "blockMoonstone", "blockSunstone",
 			"blockAmethyst", "blockMoldavite", "blockAmber", "blockTanzanite", "blockMalachite", "blockChalcedony",
-			"blockTeslaite", "blockJade", "blockPsiGem", "blockNetherStar" };
+			"blockTeslaite", "blockJade", "blockPsiGem", "blockNetherStar", "genericJewel" };
 
-	private static final String[] marbleBlocks = { "blockQuartz", "marble", "stoneMarble", "blockMarble" };
+	private static final String[] marbleBlocks = { "blockQuartz", "marble", "stoneMarble", "blockMarble", "genericMarble" };
 
 	private static final Map<String, String[]> dictionaryMaps = new HashMap<String, String[]>();
 


### PR DESCRIPTION
Modders can also hook onto these by assigning their blocks to these definitions

oreGeneric will produce a sound similar to that of most ores if a block has been added to that definition

blockMetal will produce a metallic sound if a block has been added to that definition

genericWood will produce sounds like that of wood if a block has been added to that definitiion

genericSapling will produce sounds like those of normal saplings if a block has been added to that definition

genericGlass will produce sounds like that of glass if a block has been added to that definition

genericLeaves will produce a foliage sound if a block has been added to that definition

genericStone will produce a sound similar to stone if a block has been added to that definition

genericSandstone will produce a sound similar to sandstone if a block has been added to that definition

genericSand will produce a sound similar to sand if a block has been added to that definition

genericChest will produce a sound similar to chests if a block has been added to that definition

genericWool will produce a sound similar to wool if a block has been added to that definition

genericFence will produce a sound similar to that of fences if a block has been added to that definition

genericMud will produce a muddy sound if a block has been added to that definition

genericObsidian will produce a sound similar to obsidian if a block has been added to that definition

genericJewel will produce a sound similar to various composite blocks if a block has been added to that definition

genericMarble will produce a sound similar to marble if a block has been added to that definition
